### PR TITLE
Firebase Database Helper

### DIFF
--- a/whoot/whoot.xcodeproj/project.pbxproj
+++ b/whoot/whoot.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		07964C73236A726600C5A3AC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 07964C71236A726600C5A3AC /* LaunchScreen.storyboard */; };
 		07964C7E236A726600C5A3AC /* whootTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07964C7D236A726600C5A3AC /* whootTests.swift */; };
 		07964C89236A726600C5A3AC /* whootUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07964C88236A726600C5A3AC /* whootUITests.swift */; };
+		079981F72371FB4C006DE754 /* DBHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079981F62371FB4C006DE754 /* DBHelper.swift */; };
 		07B536EA236A77EB00F70C8F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 07B536E9236A77EB00F70C8F /* GoogleService-Info.plist */; };
 		07D8DDC9236F63E80099E7F8 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07D8DDC8236F63E80099E7F8 /* HomeViewController.swift */; };
 		0A60A18A0DCEF639985C4487 /* Pods_whootUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89A95B4053003D19B95FB8AB /* Pods_whootUITests.framework */; };
@@ -56,6 +57,7 @@
 		07964C84236A726600C5A3AC /* whootUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = whootUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		07964C88236A726600C5A3AC /* whootUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = whootUITests.swift; sourceTree = "<group>"; };
 		07964C8A236A726600C5A3AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		079981F62371FB4C006DE754 /* DBHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBHelper.swift; sourceTree = "<group>"; };
 		07B536E9236A77EB00F70C8F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		07D8DDC8236F63E80099E7F8 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		1E9F70B353B1548E0F50E03B /* Pods_whoot.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_whoot.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -131,6 +133,7 @@
 		07964C65236A726300C5A3AC /* whoot */ = {
 			isa = PBXGroup;
 			children = (
+				079981F52371FB14006DE754 /* Database */,
 				07054E39236D169C00C988CB /* Authentication */,
 				07D8DDBD236EA81C0099E7F8 /* HomeView */,
 				07964C66236A726300C5A3AC /* AppDelegate.swift */,
@@ -160,6 +163,14 @@
 				07964C8A236A726600C5A3AC /* Info.plist */,
 			);
 			path = whootUITests;
+			sourceTree = "<group>";
+		};
+		079981F52371FB14006DE754 /* Database */ = {
+			isa = PBXGroup;
+			children = (
+				079981F62371FB4C006DE754 /* DBHelper.swift */,
+			);
+			path = Database;
 			sourceTree = "<group>";
 		};
 		07D8DDBD236EA81C0099E7F8 /* HomeView */ = {
@@ -420,6 +431,7 @@
 				07964C69236A726300C5A3AC /* SceneDelegate.swift in Sources */,
 				07054E3B236D16CC00C988CB /* SignInView.swift in Sources */,
 				07054E3D236D16D800C988CB /* SignUpView.swift in Sources */,
+				079981F72371FB4C006DE754 /* DBHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/whoot/whoot/Authentication/SignUpView.swift
+++ b/whoot/whoot/Authentication/SignUpView.swift
@@ -24,38 +24,26 @@ class SignUpView: UIViewController {
         guard let password = passwordField.text else { return }
         guard let email = emailField.text else  { return }
         
-        Auth.auth().createUser(withEmail: email, password: password) { result, error in
+        DBHelper.createUser(email: email, password: password) { result, error in
             if let error = error {
                 
                 // Something went wrong and we were not able to create the user's account
-                
+                // Show the user an error alert
+
                 let alert = UIAlertController(title: "Sign Up Error",
                       message: error.localizedDescription, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                 self.present(alert, animated: true)
                 
-            } else {
+            }
+            else {
+                // Successfully created the user and added them to the database
+                // Continue to home feed
                 
-                // Add user to database
-                
-                guard let uid = result?.user.uid else { return }
-                
-                let values = ["email": email]
-                
-                Database.database().reference().child("users").child(uid).updateChildValues(values, withCompletionBlock: { (error, ref) in
-                    if let error = error {
-                        print("failed to update database values \(error.localizedDescription)")
-                        return
-                    }
-                })
-                
-                // Successfully created the user
                 print("user create success")
-                
                 self.performSegue(withIdentifier: "createAccountSegue", sender: nil)
                 
             }
-            
         }
     }
 }

--- a/whoot/whoot/Database/DBHelper.swift
+++ b/whoot/whoot/Database/DBHelper.swift
@@ -1,0 +1,119 @@
+//
+//  DBHelper.swift
+//  whoot
+//
+//  Created by Carlos Estrada on 11/5/19.
+//  Copyright © 2019 Carlos Estrada. All rights reserved.
+//
+
+import Firebase
+import CoreLocation
+
+struct DBHelper {
+    
+    static var db = Database.database().reference()
+    static var users = db.child("users")
+    static var posts = db.child("posts")
+    
+    // MARK: Helper functions
+    
+    private static func getTimestampAsString() -> String {
+        let now = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        return formatter.string(from: now)
+    }
+    
+    // MARK: User Operations
+    
+    static func createUser(email: String, password: String, completion: @escaping (AuthDataResult?, Error?) -> ()) {
+        
+        Auth.auth().createUser(withEmail: email, password: password) { result, error in
+            if error != nil {
+                
+                // There was an error creating the user
+                completion(result, error)
+                
+            } else {
+                
+                // The user was created, add them to the database
+                
+                guard let uid = result?.user.uid else { return }
+                
+                
+                let userValues : [AnyHashable : Any] = [
+                    "email": email,
+                    "created_at": getTimestampAsString(),
+                    "upvotes": 0,
+                    "downvotes": 0
+                ]
+
+                users.child(uid).updateChildValues(userValues, withCompletionBlock: { (error, ref) in
+                    if let error = error {
+                        
+                        // The user couldn't be added to the database for some reason
+                        print("failed to update database values \(error.localizedDescription)")
+                        return
+                        
+                    }
+                })
+                
+                completion(result, nil)
+                
+            }
+
+        }
+    }
+    
+    func getUserByUID(uid: String) {
+        // return a user object given a valid UID
+    }
+    
+    // MARK: Post Operations
+    
+    static func createPost(postDictionary: [AnyHashable : Any], completion: @escaping (Error?, DatabaseReference?) -> ()) {
+        // We assume that we are being provided a dictionary with all the attributes of a Post object
+        // We also assume that a user is signed in
+        
+        // Create mutable (modifiable) dictionary
+        var postDict = postDictionary
+        
+        // initialize the post information
+        
+        postDict["created_at"] = getTimestampAsString()
+        postDict["downvotes"] = 0
+        postDict["upvotes"] = 0
+        
+        // Grab the current user's information for associating it with the post
+        if let user = Auth.auth().currentUser {
+            postDict["user"] = [
+                "uid": user.uid
+            ]
+        }
+        
+        // Generate a UID for the post and insert it into the database
+        let post = posts.childByAutoId()
+        post.setValue(postDict) { (error, ref) in
+            if error != nil {
+                print("Create Post Error: \(String(describing: error?.localizedDescription))")
+                completion(error, ref)
+            }
+            else {
+                completion(nil, ref)
+            }
+        }
+    }
+    
+    func getPostsByUID(uid: String) {
+        // Query for posts using the user's UID
+        // We assume that the Post object will have a fromDictionary() method that deserializes its data
+        // Return an array of Post objects associated with the provided UID
+    }
+    
+    func getPostsByLocation(location: CLLocationCoordinate2D, radiusInMiles: Int) {
+        // Check if the location is not null (ie: the user has location services on)
+        // If it's null, grab all posts (maybe)
+        // If it's available use it to query for posts within a specified mile radius
+        // Return a list of all posts within the provided location
+    }
+}

--- a/whoot/whoot/HomeView/HomeViewController.swift
+++ b/whoot/whoot/HomeView/HomeViewController.swift
@@ -17,6 +17,27 @@ class HomeViewController: UITableViewController {
 
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false
+        
+        // From Carlos: Uncomment the following to test a sample post to the database
+        // If successful, you will get an alert saying the post was successful when you launch the app
+//
+//        let testDict : [AnyHashable : Any] = [
+//            "body": "hello world!"
+//        ]
+//
+//        DBHelper.createPost(postDictionary: testDict) { (error, ref) in
+//            if error != nil {
+//                let alert = UIAlertController(title: "Error posting",
+//                      message: String(describing: error?.localizedDescription), preferredStyle: .alert)
+//                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+//                self.present(alert, animated: true)
+//            } else {
+//                let alert = UIAlertController(title: "Success!",
+//                      message: "Successfully posted", preferredStyle: .alert)
+//                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+//                self.present(alert, animated: true)
+//            }
+//        }
     }
     
     // MARK: - Sign Out


### PR DESCRIPTION
## Changes
- Create a database wrapper `DBHelper` for easily inserting user data and posts into Firebase
- Use `DBHelper` to sign up users and store their data in the database
- Add a test to `HomeViewController` that, when uncommented, will automatically try to send a sample post to the database.
    - If signed in and the test passes, you will get a system alert saying it was successful
    - If the test fails, you will get a system alert describing the error

**Note:** Posts are currently handled as dictionaries, since Firebase prefers them in this format.